### PR TITLE
Standalone Frontend Framework (angularjs-snapper)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -51,6 +51,6 @@ class Widget(API_Model):
         ''' Overload to load the template as if it were any other model '''
 
         if self.name:
-            with open(os.path.join(settings.STATIC_ROOT, 'widgets/{}/{}.html'.format(self.name, self.name))) as template:
+            with open(os.path.join(settings.STATIC_ROOT, 'widgets/{}.html'.format(self.name, self.name))) as template:
                 return {'name': self.name, 'template': template.read()}
 

--- a/static/js/fixtures.js
+++ b/static/js/fixtures.js
@@ -1,5 +1,17 @@
-// REGISTER ANGULAR JS FIXTURES HERE:
+/**
+    FIXTURE SPECIFICS
+        modules
+            Custom Angular modules defined in any script included in the DOM should be
+            registered here. This allows any number of modules to be mixed and matched.
+        
 
+        widgets
+            Templates to compile with (optional) models from the API. Registered widgets
+            can be added to the DOM using a specified tag (e.g. <widget-name></widget-name>).
+
+        routes
+            Routes and associated pages to be used by ngRoute in Single Page Applications.
+**/
 
 var Fixtures = {
 
@@ -7,45 +19,58 @@ var Fixtures = {
 
     ],
 
-    widgets: [
+    widgets: [ 
+    /* 
+        {
+            name:               The name to use for the widget (and the html tag that renders the widget).
+            template_url:       The URL to fetch the widget template from (Optional - defaults to <<settings.default_api_url>> if 'template' not specified).
+            template:           The widget template in string form (Optional - if template_url is specified).
+            template_data_path: A dot-seperated path to use part of the API response JSON as template. 
+                                (e.g. data.templates.navbar). (Optional - defaults to <<settings.default_template_data_path>>)
+            models:             A list of objects to fetch from one or more APIs to compile the template with.
+            [
+                {
+                    model:              The name of the model to retrieve.
+                    scope_key:          The key used to store the retrieved models in the scope (and to reference them in the template) 
+                                        (Optional - defaults to the model name).
+                    url:                The url of the API to fetch the model from. (Optional - defaults to <<settings.default_api_url>>)
+                    data_path:          A dot-seperated path to use part of the API response JSON as the model 
+                                        (e.g. data.authors.Stephen_King). (Optional - defaults to <<settings.default_models_data_path>>)
+                }
+            ],
+            models_override:   A list of pre-fetched objects to compile the template with.
+            [ 
+                {
+                    model:             The name of the model (Optional). 
+                    scope_key:         The key used to store the retrieved models in the scope.
+                                       (and to reference them in the template) (Optional - defaults to 'model'
+                                       if specified otherwise <<settings.default_model_scope_key>>).
+                    
+                    ...                The rest of the pre-fetched model's attributes.
+                }
+            ],
+        }, 
+    */
         {
             name: 'header',
         },
 
         {
             name: 'sidebar',
-            models: [{'model': 'category'}]
+            models: [{'model': 'category', 'scope_key': 'categories'}],
         },
     ],
 
     routes: [
 
-    ]
+    ],
+
+    settings: {
+        default_api_url: '/api/',
+        default_models_data_path: 'data.models',
+        default_model_scope_key: 'models+',
+        default_template_data_path: 'data.models.0.template',
+        DOM_attach_point: 'body',
+    }
 };
 
-
-/**
-    FIXTURE SPECIFICS
-        modules
-            Custom Angular modules defined in any script included in the DOM should be
-            registered here. This allows any number of modules to be mixed and matched.
-        
-            Parameters:
-                name - The name of the module.
-                // TODO - services
-
-        widgets
-            Templates to compile with (optional) models from the API. Registered widgets
-            can be added to the DOM using a specified tag (e.g. <widget-name></widget-name>).
-            Templates and stylesheets used to render the widgets are delivered by the API and are stored on the 
-            server in <<STATIC_ROOT>/widgets/.
-
-            Parameters:
-                name - The name of the widget (will be the HTML tag that renders the widget).
-                models - A list of models to compile the template with, in the proper format for GET() (e.g. {'model': 'mymodel'} or 
-                        {'model': 'mymodel', 'filter': 'name:model_name'}). Optional.
-                html_template - The template to use when rendering the widget. <<STATIC_ROOT>/widgets/<<name>>.html by default. Optional.
-
-        routes
-            Routes and associated pages to be used by ngRoute in Single Page Applications.
-**/

--- a/static/js/libraries/api.js
+++ b/static/js/libraries/api.js
@@ -1,25 +1,26 @@
 // Library for interacting with the server's API
-
-var API = {
-    GET: function($http, params, callback, key) {
+angular.module('API_Library', []).service('API', ['$http', function ($http) { 
+    this.GET = function({url, params, callback, response_data_path}) {
         /**
             Simplifies the boilerplate code necessary to send an AngularJS GET request to the server.
             IMPORTANT: Since requests are asynchronous, function passes the returned response to a
             callback function when received and DOES NOT return the response.
            
             --> $http - The AngularJS HTTP serviced passed from the controller sending the request.
+            --> url - The url to send the GET request to.
             --> params - A map of parameters to send with the request (e.g. {'model': 'mymodel'}).
             --> callback - The function to call when a response from the server is received. *The passed
                            callback function MUST specify a response parameter (e.g. func(response){})*.
-            --> key - A dot seperated path to specify a partial chunk of the response to send to the callback 
-                      (e.g. 'model.name' to access the sub-value name of the value model in the response).
+            --> response_data_path - A dot seperated path to specify a partial chunk of the response to send to the callback 
+                                     instead of the whole response (e.g. 'model.name' to access the sub-value name 
+                                     of the value model in the response).
         **/
     
-        $http({ url: '/api/',  method: "GET",  params: params })
-        .then((! key) ? callback : function(response) { API.parse_response(response, key, callback); });
-    },
+        $http({ url: (url) ? url : Fixtures.settings.default_api_url, method: "GET",  params: params })
+        .then((! response_data_path) ? callback : (response) => API.parse_response(response, response_data_path, callback));
+    };
     
-    parse_response: function(response, key, callback) {
+    this.parse_response = function(response, key, callback) {
         /**
             Handles parsing the JSON response for the specified value or sub-value.
            
@@ -30,14 +31,12 @@ var API = {
                            callback function MUST specify a response parameter (e.g. func(response){})*.
         **/
     
-        key.split('.').forEach(function(path) { 
-            response = (Array.isArray(response[path])) ? API.fix_json_list(response[path]) : response[path]; 
-        });
+        key.split('.').forEach((path) => response = (Array.isArray(response[path])) ? API.fix_json_list(response[path]) : response[path]);
     
         callback(response);
-    },
+    };
     
-    fix_json_list: function(json_list) {
+    this.fix_json_list = function(json_list) {
         /**
             Fixes nested JSON in lists (if it is in string form). Fixes occur on-demand by either calling function
             with a list of JSON in string form, or when a parsing a response in parse_response().
@@ -47,8 +46,6 @@ var API = {
             <-- List<Object> A list of containing the parsed JSON objects.
         **/
     
-        try {
-            return json_list.map(JSON.parse);
-        } catch (e) { return json_list; }
-    }
-};
+        try { return json_list.map(JSON.parse); } catch (e) { return json_list; }
+    };
+}]);

--- a/static/js/libraries/bootstrapper.js
+++ b/static/js/libraries/bootstrapper.js
@@ -1,6 +1,6 @@
 // Library for loading arbitrary modules, routes and widgets from a specified fixtures file (fixtures.js).
 
-var Bootstrapper = {
+var Bootstrapper =  {
     bootstrap: function() {
         /**
                                         *CALLED AUTOMATICALLY*
@@ -8,13 +8,12 @@ var Bootstrapper = {
         **/
 
         angular.element(document).ready(function () { 
-            Fixtures.widgets.map(function(widget) { Bootstrapper.register_widget(widget.name, widget.models, widget.template); });
-            
-            angular.bootstrap(angular.element(document).find('body'), Fixtures.modules);
+            Fixtures.widgets.map(widget => Bootstrapper.register_widget(widget));
+            angular.bootstrap(angular.element(document).find(Fixtures.settings.DOM_attach_point), Array.from(Fixtures.modules));    
         });
     }(),
 
-    register_widget: function(name, models, html_template) {
+    register_widget: function({name, models, directive_template, models_override, template_override}) {
         /**
             Register a widget that can be added to the DOM with a custom HTML tag. Widgets should be declared in a fixtures.js
             or by calling this function ( Bootstrapper.register_module() ).
@@ -22,40 +21,57 @@ var Bootstrapper = {
             A widget is an HTML template and an optional set of models from the API that is fetched, compiled, and displayed when 
             specified on the DOM using an HTML tag of the widget's name (e.g. <widget-name></widget-name>).
             
-            --> name - The name of the widget to register (and tag to render the widget on the DOM).
+            --> name - The name of the widget template to register. *Becomes an HTML tag that can render the widget on the DOM*
             --> models - A list of models (with optional filter and sort) to compile the template with, in the proper format for GET() (e.g. {'model': 'mymodel'} or 
                         {'model': 'mymodel', 'filter': 'name:model_name'}). Optional.
-            --> html_template - The template to specify in the directive. Optional.
+            --> directive_template - The template to specify in the directive. Optional.
+            --> models_override - A list of objects to compile the widget with. Optional. *If models is also specified, the models fetched from the API are combined
+                                    with the passed models*
+            --> template_override - An HTML template (in string form) to use to render the widget. Used in place of fetching the template from the API. 
+                                    Optional (must specify template_name if not used).
         **/
-    
-        var widget_module = angular.module(name + '-widget', []); // Widget module can be referenced as <<name>>-widget.
-        
-        widget_module.directive(name, function($http, $compile) { // Link the custom HTML tag to the widget renderer.
-            return {
-                restrict: 'E',
-                template: html_template,
-                link: function($scope, element) { Renderer.render_template($scope, $http, $compile, element, models, name); },
-            };
-        });
 
-        Bootstrapper.register_module(widget_module.name);
+        var Renderer = Bootstrapper.fetch_module_service('Renderer');
+
+        var new_widget_module = angular.module(name, []); // Widget module can be referenced as <<name>>-widget.
+        
+        new_widget_module.directive(name, () => // Link the custom HTML tag to the widget renderer.
+            ({
+                restrict: 'E',
+                template: directive_template,
+                link: function($scope, element) { Renderer.render_template($scope, element, models, name, models_override, template_override); },
+            })
+        );
+
+        this.register_module(new_widget_module.name);
     },
 
-    register_module: function(name, create) { // TODO - ALLOW SERVICE INJECTION
+    register_module: function(name, create) {
         /**
             Register or create an AngularJS module to use in the application. Modules can be declared in any script included in the DOM but must be 
             registered in fixtures.js or by calling this function ( Bootstrapper.register_module() ) before they can be used.
             
             --> name - The name of the module to register.
             --> create - True if the module should be created as it is being registered. False (or null) if the module has
-                         already been created.
+                            already been created.
 
             <-- AngularJS Module if a model was created. Otherwise null. 
         **/
 
         Fixtures.modules.push(name);
 
-        if(create)
-            return angular.module(name, []);
-    }
+        return (create) ? angular.module(name, []) : null;
+    },
+
+    fetch_module_service: (service_name, library_name) => 
+        /**
+            Allow access to the service of a declared AngularJS module without injecting it directly.
+
+            --> service_name - The name of the service to access.
+            --> library_name - The name of the module to access. Optional, defaults to <<service_name>>_Library.
+
+            <-- AngularJS Module if a model was created. Otherwise null. 
+        **/
+
+        angular.injector(['ng', (library_name) ? library_name : `${service_name}_Library`]).get(service_name)
 };

--- a/static/js/libraries/renderer.js
+++ b/static/js/libraries/renderer.js
@@ -1,40 +1,114 @@
 // Library for rendering widgets.
 
-var Renderer = {
-    render_template: function($scope, $http, $compile, element, models, template) {
+angular.module('Renderer_Library', []).service('Renderer', ['$compile', function ($compile) { 
+    this.render_template = function(scope, element, models, template_name, models_override, template_override) {
         /**
-         *  Fetch a template and models from the API. Compile the template with the fetched data and add it to 
-         *  the passed DOM element.
-         * 
-         *  --> $scope - The scope passed from the directive link function.
-         *  --> $http - The http service passed from the directive link function.
-         *  --> $compile - The compile service passed from the directive link function.
-         *  --> element - The DOM element to add the template to. Passed from the directive link function.
-         *  --> models - A list of models to compile the template with, in the proper format for GET() (e.g. {'model': 'mymodel'} or 
-         *              {'model': 'mymodel', 'filter': 'name:model_name'}). Optional.
-         *  --> template - The name of the template to load (excluding the extension).
+            Fetch a template and models from the API. Compile the template with the fetched data and add it to 
+            the passed DOM element.
+           
+            --> scope - The scope passed from the directive link function.
+            --> element - The DOM element to add the template to. Passed from the directive link function.
+            --> models - A list of models to compile the template with, in the proper format for GET() (e.g. {'model': 'mymodel'} or 
+                        {'model': 'mymodel', 'filter': 'name:model_name'}). Optional.
+            --> template_name - The name of the template to load from the API (excluding the extension).
+            --> models_override - A list of objects to compile the widget with. Optional. *If models is also specified, the models fetched from the API are combined
+                                  with the passed models*
+            --> template_override - An HTML template (in string form) to use to render the widget. Used in place of fetching the template from the API. 
+                                    Optional (must specify template_name if not used).
         **/
+
+        Renderer = this;
+        API = Bootstrapper.fetch_module_service('API');
     
         if(models && models.length > 0) // Since API.GET runs asynchronously, recurse to get all models from the API using API.GET's optional
-            API.GET(                    // callback.
-                $http, 
-                models[0], 
-                function(response) {
-                    $scope[models[0].model] = response; 
-                    Renderer.render_template($scope, $http, $compile, element, models.slice(1), template); 
+            API.GET({                   // callback. 
+                url: models[0].url,
+                params: models[0], 
+                callback: function(response) {
+                    scope[Renderer.pop_model_key(models[0])] = response; 
+                    Renderer.render_template(scope, element, models.slice(1), template_name, models_override, template_override); 
                 }, 
-                'data.models'
-            );
-        else                            // The final recursive call (after all models are retrieved) compiles and displays the widget.
-            API.GET(
-                $http,
-                {'model': 'widget', 'filter': 'name:' + template},
-                function(template) { 
-                    element.append($compile(template)($scope));
-                },
-                'data.models.0.template'
-            );
-    }
-};
+                response_data_path: Fixtures.settings.default_models_data_path
+            });
+
+        // TODO - ADD OVERRIDES FOR URL PER TEMPLATE?
+        else if (! template_override) // The final recursive call if loading the template from the API.
+            API.GET({                 // Fetches the template after all models are retrieved, compiles them with the template.
+                params: {'model': 'widget', 'filter': `name:${template_name}`},
+                callback: (template) => Renderer.add_to_DOM(scope, element, template, models_override),
+                response_data_path: Fixtures.settings.default_template_data_path
+            });
+
+        else                          // The final recursive call if loading the template directly (as a string).
+            Renderer.add_to_DOM(scope, element, template_override, models_override);
+    };
+
+    this.splice_models = function(scope, models_override) {
+        /**
+            Combine passed objects with objects fetched from the API as neatly as possible.
+            If the passed objects have a <<model>> attribute, they will be stored by that key
+            in the scope the template is compiled with (e.g. {'model': 'extra'} would be 
+            referenced as {{ extra }} on the DOM). Multiple models of the same name are stored as
+            a list. 
+            
+            *The default key is +models ( {{ +models }} on the DOM )*
+           
+            --> scope - The scope containing the models loaded from the API.
+            --> models_override - A list of objects to add to the scope.
+        **/
+
+        models_override && models_override.forEach(model => {
+            model_name = Renderer.pop_model_key(model);
+
+            if (model_name)             
+            { 
+                if(scope[model_name]) // Existing Name
+                    (Array.isArray(scope[model_name])) ? scope[model_name].push(model) : scope[model_name] = [scope[model_name], model];
+
+                else                   // New Name
+                    scope[model_name] = model;
+            }
+            
+            else                      // Store with Default Key
+                (scope[Fixtures.settings.default_model_scope_key]) ? 
+                    scope[Fixtures.settings.default_model_scope_key].push(model) : 
+                    scope[Fixtures.settings.default_model_scope_key] = [model];
+        });
+    };
+
+    this.add_to_DOM = function(scope, element, template, models_override) { 
+        /**
+            Final logic used by render_template() to compile the template
+            into an HTML element and add it to the DOM.
+            
+            --> scope - The scope containing the models loaded from the API.
+            --> element - The DOM element to append the template to.
+            --> template - The HTML template to add to the DOM (in string form).
+            --> models_override - A list of objects to add to the scope.
+        **/
+       
+        Renderer.splice_models(scope, models_override);
+        element.append($compile(template)(scope));
+        scope.$apply();
+    };
+
+    this.pop_model_key = function(model) {
+        /**
+            Remove and return the key to be used to store the model
+            in the scope. Uses the 'scope_key' attribute if specified or
+            the 'model' attribute if no host key is specified.
+            
+            --> model - The model to remove the name from.
+            <-- (String || null) - The model name (if it exists).
+        **/
+
+        var model_name = (model.scope_key) ? model.scope_key : (model.model) ? model.model : null;  
+        delete model.model && delete model.scope_key;
+
+        return model_name;
+    };
+}]);
+
+
 
 

--- a/static/widgets/sidebar.html
+++ b/static/widgets/sidebar.html
@@ -1,5 +1,5 @@
 <div class="sidebar">
-    <div ng-repeat="c in category track by $index" ng-mouseover="sb_hover=true" class="sidebar_item">
+    <div ng-repeat="c in categories track by $index" ng-mouseover="sb_hover=true" class="sidebar_item">
         <i class="material-icons-round">{{ c.icon }}</i>
         <p>{{ c.name }}</p>
     </div>


### PR DESCRIPTION
Rebuilt the simple widget framework as a standalone plugin that mimics Angular2 components in
AngularJS while maintaining the MVC architecture and fully asynchronous rendering. 

Changelog:
- Refactored API and Renderer library objects into AngularJS modules to allow implicit access to AngularJS services in library methods.
- API.GET() no longer hardcoded to this app's API and can fetch resources from an arbitrary endpoint.
- Added Bootstrapper.fetch_module_service() to access module libraries outside of AngularJS.
- Widgets are now far more configurable when loading from Fixtures:
  - Templates can be passed directly as a string as an alternative to loading them from an API.
  - Individual models can specify the API they should be retrieved from and the key used to
     reference them on the template.
  - Internal models may be specified in addition to (or instead of) models retrieved from an API. They are combined with any models loaded from an API that share the same name or specified key.
- Default settings added to Fixtures.js for:
  - Parsing GET responses.
  - Model template keys.
  - An API URL.
  - The DOM element to bootstrap the framework to.
- Improved Fixtures.js documentation. 
- Added es6 Javascript syntax where useful.